### PR TITLE
docs: improve installation guide with configuration steps and API key explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pip install tokligence
 
 ### Node.js (npm)
 ```bash
-npm i @tokligence/gateway
+npm i -g @tokligence/gateway
 ```
 
 ### From Source
@@ -142,6 +142,40 @@ npm i @tokligence/gateway
 git clone https://github.com/tokligence/tokligence-gateway
 cd tokligence-gateway
 make build
+```
+
+## Configuration
+
+After installation, configure an LLM endpoint before using `tgw chat`:
+
+### Option 1: Local LLMs (Free)
+```bash
+# Using Ollama (https://ollama.ai)
+ollama serve
+ollama run llama3
+tgw chat "Hello!"
+```
+
+### Option 2: Commercial APIs
+```bash
+# OpenAI
+export TOKLIGENCE_OPENAI_API_KEY=sk-...
+tgw chat "Hello!"
+
+# Anthropic
+export TOKLIGENCE_ANTHROPIC_API_KEY=sk-ant-...
+tgw chat "Hello!"
+
+# Google
+export TOKLIGENCE_GOOGLE_API_KEY=AIza...
+tgw chat "Hello!"
+```
+
+### Option 3: Custom Endpoint
+```bash
+export TOKLIGENCE_LLM_ENDPOINT=http://your-llm.com/v1
+export TOKLIGENCE_LLM_API_KEY=optional-key
+tgw chat "Hello!"
 ```
 
 ## Why Tokligence Gateway?

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -37,6 +37,57 @@ curl -H "Authorization: Bearer <api_key>" \
 
 The built‑in `loopback` model echoes input without calling external LLMs, ideal for verifying authentication and connectivity.
 
+## Understanding API Keys
+
+Tokligence Gateway uses **two types of API keys** that serve different purposes:
+
+### 1. Gateway API Keys (User Authentication)
+
+These are keys that **you create** for users to access your gateway:
+
+```bash
+# Create a gateway API key for a user
+./bin/gateway admin api-keys create --user <user_id>
+# Returns: tok_xxxxxxxxxxxx
+```
+
+- **Purpose**: Authenticate users/applications to your Tokligence Gateway
+- **Who creates them**: You (the gateway administrator)
+- **Format**: `tok_xxxxxxxxxxxx`
+- **Used in**: `Authorization: Bearer tok_xxxxxxxxxxxx` header when calling your gateway
+
+### 2. LLM Provider API Keys (Backend Connection)
+
+These are keys from **external LLM providers** that the gateway uses to forward requests:
+
+```bash
+# Configure LLM provider keys (environment variables)
+export TOKLIGENCE_OPENAI_API_KEY=sk-...           # From OpenAI
+export TOKLIGENCE_ANTHROPIC_API_KEY=sk-ant-...    # From Anthropic
+export TOKLIGENCE_GOOGLE_API_KEY=AIza...          # From Google
+```
+
+- **Purpose**: Allow the gateway to connect to upstream LLM providers
+- **Who creates them**: The LLM provider (OpenAI, Anthropic, Google, etc.)
+- **Format**: Provider-specific (e.g., `sk-...` for OpenAI)
+- **Used by**: The gateway internally when routing requests to providers
+
+### How They Work Together
+
+```
+┌─────────────┐    Gateway API Key     ┌─────────────────────┐    LLM Provider Key    ┌──────────────┐
+│   Client    │ ───────────────────▶  │  Tokligence Gateway │ ────────────────────▶ │  OpenAI/     │
+│ (your app)  │   tok_xxxxxxxxxxxx    │                     │   sk-proj-...         │  Anthropic   │
+└─────────────┘                        └─────────────────────┘                        └──────────────┘
+```
+
+1. Your application authenticates to the gateway using a **Gateway API Key**
+2. The gateway validates the request and routes it to the appropriate provider
+3. The gateway uses the **LLM Provider API Key** to call OpenAI/Anthropic/etc.
+4. The response flows back through the gateway to your application
+
+> **Note**: For local LLMs (Ollama, vLLM, LM Studio), no LLM Provider API Key is needed—just configure the endpoint URL.
+
 ## Configuration
 
 Configuration loads in three layers:


### PR DESCRIPTION
## Summary

This PR improves the documentation to help new users get started more easily.

### Changes

**README.md:**
- Added `-g` flag to npm install command for global installation
- Added new **Configuration** section after Installation with three options:
  - Option 1: Local LLMs (Ollama)
  - Option 2: Commercial APIs (OpenAI, Anthropic, Google)
  - Option 3: Custom Endpoint

**docs/QUICK_START.md:**
- Added **Understanding API Keys** section explaining the difference between:
  - **Gateway API Keys** (`tok_xxx`) - for user authentication to the gateway
  - **LLM Provider API Keys** (`sk-...`) - for the gateway to connect to upstream providers
- Includes ASCII diagram showing how both keys work together in the request flow

### Why

Users were confused when running `tgw chat` after installation and seeing 'No LLM endpoints detected'. These additions clarify:
1. What configuration is needed after installation
2. The difference between the two types of API keys in the system