### PR TITLE
feat: rename filter config to generic names and add header support

### DIFF
--- a/config/firewall.ini
+++ b/config/firewall.ini
@@ -1,11 +1,18 @@
 # ==============================================================================
 # Tokligence Gateway Prompt Firewall Configuration
 # ==============================================================================
-# The firewall protects against PII leakage and sensitive data exposure
-# in both user prompts (input) and LLM responses (output).
+# The firewall protects against sensitive data leakage in both user prompts
+# (input) and LLM responses (output).
+#
+# Sensitive Data (SD) includes:
+#   - Email addresses, phone numbers, physical addresses
+#   - National IDs (SSN, Chinese ID, passport numbers)
+#   - Financial data (credit cards, bank accounts)
+#   - API keys, secrets, passwords, private keys
+#   - Crypto addresses, medical IDs, tax IDs
 #
 # Configuration Hierarchy (priority from high to low):
-# 1. Environment variables (e.g., TOKLIGENCE_PROMPT_FIREWALL_MODE, TOKLIGENCE_PROMPT_FIREWALL_ENABLED)
+# 1. Environment variables (e.g., TOKLIGENCE_PROMPT_FIREWALL_MODE)
 #    - Highest priority, overrides everything
 # 2. This firewall.ini file
 #    - Main firewall configuration
@@ -14,111 +21,50 @@
 #
 # Modes:
 #   - disabled: Firewall completely disabled (default in code)
-#   - redact:   Detect PII → Replace with tokens → Restore in responses (RECOMMENDED for production)
+#   - redact:   Detect SD -> Replace with tokens -> Restore in responses (RECOMMENDED)
 #   - monitor:  Log violations but allow requests through (for testing)
 #   - enforce:  Block requests that violate policies (strict mode)
-#
-# Note: The default in code is "disabled". To enable firewall, uncomment this file
-# and set mode to "redact" (recommended) or another mode.
 #
 # Environment variable overrides:
 #   TOKLIGENCE_PROMPT_FIREWALL_MODE=redact|monitor|enforce|disabled
 #   TOKLIGENCE_PROMPT_FIREWALL_ENABLED=true|false
-#   TOKLIGENCE_PROMPT_FIREWALL_CONFIG=path/to/firewall.ini  (to use a different config file)
+#   TOKLIGENCE_PROMPT_FIREWALL_CONFIG=path/to/firewall.ini
 # ==============================================================================
 
 [prompt_firewall]
 enabled = true
 mode = redact
 
-# PII patterns configuration file
+# SD patterns configuration file
 pii_patterns_file = config/pii_patterns.ini
 
 # Enabled regions (comma-separated)
 # Available: global, us, cn, eu, uk, ca, au, in, jp, de, fr, sg
-# Leave empty to use defaults from pii_patterns.ini
 pii_regions = global,us,cn
 
-# Alternatively, specify exact PII types (comma-separated, overrides regions if set)
-# Available types: EMAIL, PHONE, SSN, CREDIT_CARD, IP_ADDRESS, API_KEY, CRYPTO_ADDRESS,
-#                  NATIONAL_ID, PASSPORT, DRIVERS_LICENSE, BANK_ACCOUNT, TAX_ID, MEDICAL_ID, etc.
-# pii_types = EMAIL,PHONE,SSN,NATIONAL_ID,API_KEY
-
-# ==============================================================================
-# Presidio Sidecar Supported PII Types (when filter_presidio_enabled = true)
-# ==============================================================================
-# The Presidio sidecar provides enhanced PII detection including:
-#
-# Critical Severity (blocks request in enforce mode):
-#   - CREDIT_CARD: Credit card numbers (all major types)
-#   - US_SSN: US Social Security Numbers (xxx-xx-xxxx)
-#   - PASSPORT: International passport numbers (22 countries - see below)
-#   - CN_ID_CARD: Chinese national ID (18-digit 身份证)
-#
-# Medium Severity:
-#   - EMAIL_ADDRESS: Email addresses
-#   - PHONE_NUMBER: Phone numbers (US, UK, CN, SG, international)
-#   - VEHICLE_PLATE: Vehicle license plates (China only)
-#
-# Low Severity:
-#   - PERSON: Person names (English, Chinese with XLM-RoBERTa)
-#   - LOCATION: Locations/addresses
-#   - IP_ADDRESS: IP addresses (IPv4, IPv6)
-#   - URL: Web URLs
-#
-# Passport Detection (22 countries):
-#   Asia:        CN, JP, KR, IN, SG, MY, TH, PH
-#   Europe:      UK, DE, FR, IT, ES, PL, RU
-#   Americas:    US, CA, MX, BR
-#   Oceania:     AU, NZ
-#   Middle East: UAE, SA
-#
-# Note: US/UK/UAE passports require context keywords (e.g., "passport: 123456789")
-#       to avoid false positives with other 9-digit numbers.
-#
-# Test passport detection: ./tests/firewall/test_passport_recognizer.sh
-# ==============================================================================
-
 # Minimum confidence threshold (0.0-1.0)
-# Only detections above this threshold will trigger actions
 pii_min_confidence = 0.75
 
 # Log all firewall decisions (useful for debugging)
 log_decisions = true
 
-# Log PII values in debug mode (WARNING: disable in production for security)
+# Log sensitive values in debug mode (WARNING: disable in production)
 log_pii_values = false
 
-# Maximum PII entities in a single request (soft limit, logs warning if exceeded)
+# Maximum SD entities in a single request (soft limit, logs warning if exceeded)
 max_pii_entities = 50
 
 # ==============================================================================
-# SSE Streaming Configuration (for redact mode with streaming responses)
+# SSE Streaming Configuration (for redact mode)
 # ==============================================================================
-# When streaming responses contain PII tokens (e.g., [PERSON_abc123]), they may
-# be split across multiple SSE chunks. These settings control buffering behavior
-# to ensure proper detokenization.
-
-# Maximum time (ms) to wait for closing bracket before force flushing buffer.
-# Note: SSE chunks have ~20-50ms delays, tokens take ~300-450ms to complete.
-# Increase this if tokens are being prematurely flushed in slow networks.
 # redact_sse_buffer_timeout_ms = 500
-
-# Maximum characters to buffer while waiting for closing bracket.
-# Normal PII tokens are ~20 chars (e.g., [PERSON_abc123]), 30 gives buffer.
 # redact_sse_max_buffer_length = 30
 
 # ==============================================================================
-# PII Tokenizer Configuration (for redact mode)
+# Tokenizer Configuration (for redact mode)
 # ==============================================================================
 [tokenizer]
-# Storage backend: memory | redis | redis_cluster
-# - memory: Fast, single-instance, lost on restart (default for dev)
-# - redis: Persistent, supports multiple gateway instances
-# - redis_cluster: High availability, distributed
 store_type = memory
-
-# Time-to-live for token mappings (duration format: 1h, 30m, etc.)
 ttl = 1h
 
 # Redis configuration (only used if store_type = redis)
@@ -127,42 +73,44 @@ ttl = 1h
 # redis_db = 0
 # redis_key_prefix = firewall:tokens
 
-# Redis Cluster configuration (only used if store_type = redis_cluster)
-# redis_cluster_addrs = redis-node1:7000,redis-node2:7001,redis-node3:7002
-# redis_cluster_key_prefix = firewall:tokens
-
 # ==============================================================================
 # Input Filters (applied to user prompts before sending to LLM)
 # ==============================================================================
 [firewall_input_filters]
-# Built-in PII regex filter (fast, no external dependencies)
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
 
-# External Presidio service (optional, higher accuracy)
-# Start Presidio sidecar with: make pii-start (uses XLM-RoBERTa by default)
-# Or use shortcut: make psx
-# XLM-RoBERTa provides best multilingual accuracy, especially for Chinese names
-# Performance: ~400ms/500KB on CPU, supports 12 languages
-filter_presidio_enabled = true
-filter_presidio_priority = 20
-filter_presidio_endpoint = http://localhost:7317/v1/filter/input
-filter_presidio_timeout_ms = 5000
-filter_presidio_on_error = allow
+# Built-in Sensitive Data regex filter (fast, no external dependencies)
+# Detects: EMAIL, PHONE, SSN, CREDIT_CARD, API_KEY, CRYPTO_ADDRESS, etc.
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
+
+# External HTTP filter (for external scanning services)
+# Can be used with Tokligence Guard, Presidio, or other scanning APIs
+# Example: Tokligence Guard Protection Engine
+#   filter_http_endpoint = https://us.guard.tokligence.ai:7316/v1/filter/input
+#   filter_http_header_X-API-Key = tok_your_api_key_here
+filter_http_enabled = true
+filter_http_priority = 20
+filter_http_endpoint = http://localhost:7317/v1/filter/input
+filter_http_timeout_ms = 5000
+filter_http_on_error = allow
+# Custom headers for authentication (uncomment and set your API key)
+# filter_http_header_X-API-Key = tok_your_api_key_here
+# filter_http_header_Authorization = Bearer your_token_here
 
 # ==============================================================================
 # Output Filters (applied to LLM responses before returning to user)
 # ==============================================================================
 [firewall_output_filters]
-# Built-in PII regex filter for detokenization
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
 
-# Presidio output filter (for detecting PII in LLM responses)
-# NOTE: Disabled in redact mode because Presidio re-redacts the output
+# Built-in Sensitive Data regex filter for detokenization
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
+
+# External HTTP filter (output scanning)
+# NOTE: Disabled in redact mode because it re-redacts the output
 # which conflicts with detokenization. Enable only in monitor/enforce modes.
-filter_presidio_enabled = false
-filter_presidio_priority = 20
-filter_presidio_endpoint = http://localhost:7317/v1/filter/output
-filter_presidio_timeout_ms = 5000
-filter_presidio_on_error = allow
+filter_http_enabled = false
+filter_http_priority = 20
+filter_http_endpoint = http://localhost:7317/v1/filter/output
+filter_http_timeout_ms = 5000
+filter_http_on_error = allow

--- a/docs/TOKLIGENCE_GUARD_INTEGRATION.md
+++ b/docs/TOKLIGENCE_GUARD_INTEGRATION.md
@@ -1,0 +1,216 @@
+# Tokligence Guard Integration Guide
+
+This guide explains how to integrate Tokligence Gateway with [Tokligence Guard](https://guard.tokligence.ai) for enterprise-grade sensitive data protection.
+
+## Overview
+
+Tokligence Guard provides a cloud-based sensitive data scanning service that detects and protects:
+
+- **Personal Information**: Email, phone, physical addresses
+- **National IDs**: SSN, Chinese ID (身份证), passport numbers
+- **Financial Data**: Credit cards, bank accounts
+- **Secrets**: API keys, passwords, private keys
+- **Other**: Crypto addresses, medical IDs, tax IDs
+
+By integrating with Tokligence Guard, your Gateway can scan all LLM requests for sensitive data before they reach the AI provider.
+
+## Architecture
+
+```
+Coding Agent (Cursor, Claude Code, etc.)
+    │
+    │ LLM API Request
+    ▼
+Tokligence Gateway (self-hosted)
+    │
+    │ Sensitive Data Scan Request
+    │ (with API Key authentication)
+    ▼
+Tokligence Guard Protection Engine (cloud)
+    │
+    │ Scan Result (allow/block/redact)
+    ▼
+Gateway continues to LLM or blocks request
+```
+
+## Prerequisites
+
+1. **Tokligence Guard Account**: Sign up at [guard.tokligence.ai](https://guard.tokligence.ai)
+2. **API Key**: Generate an API key from the Guard dashboard (Settings → API Keys)
+3. **Tokligence Gateway**: Version 0.4.0 or later
+
+## Configuration
+
+### Step 1: Edit firewall.ini
+
+Open your Gateway's `config/firewall.ini` file:
+
+```ini
+# ==============================================================================
+# Tokligence Gateway Firewall Configuration
+# ==============================================================================
+
+[prompt_firewall]
+enabled = true
+mode = redact    # Options: disabled, monitor, enforce, redact
+
+# ==============================================================================
+# Input Filters
+# ==============================================================================
+[firewall_input_filters]
+
+# Built-in Sensitive Data regex filter (fast, local)
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
+
+# Tokligence Guard HTTP filter (cloud-based, high accuracy)
+filter_http_enabled = true
+filter_http_priority = 20
+filter_http_endpoint = https://us.guard.tokligence.ai:7316/v1/filter/input
+filter_http_timeout_ms = 5000
+filter_http_on_error = allow
+filter_http_header_X-API-Key = tok_your_api_key_here
+
+# ==============================================================================
+# Output Filters (optional)
+# ==============================================================================
+[firewall_output_filters]
+
+# Built-in filter for detokenization in redact mode
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
+```
+
+### Step 2: Choose Your Region
+
+Tokligence Guard is available in multiple regions. Use the endpoint closest to you:
+
+| Region | Endpoint |
+|--------|----------|
+| US | `https://us.guard.tokligence.ai:7316/v1/filter/input` |
+| EU | `https://eu.guard.tokligence.ai:7316/v1/filter/input` |
+| Asia | `https://asia.guard.tokligence.ai:7316/v1/filter/input` |
+
+### Step 3: Set Your API Key
+
+Replace `tok_your_api_key_here` with your actual API key from the Guard dashboard.
+
+You can also use environment variables for security:
+
+```bash
+export TOKLIGENCE_GUARD_API_KEY="tok_your_api_key_here"
+```
+
+Then reference it in your startup script or use a config template.
+
+## Firewall Modes
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `disabled` | No scanning | Development/testing |
+| `monitor` | Log detections, allow all requests | Initial deployment, auditing |
+| `enforce` | Block requests with critical data | Strict security |
+| `redact` | Replace sensitive data with tokens, restore in responses | **Recommended for production** |
+
+## Configuration Options
+
+### HTTP Filter Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `filter_http_enabled` | Enable/disable the filter | `false` |
+| `filter_http_priority` | Execution order (lower = earlier) | `20` |
+| `filter_http_endpoint` | Guard API endpoint URL | - |
+| `filter_http_timeout_ms` | Request timeout in milliseconds | `5000` |
+| `filter_http_on_error` | Behavior on error: `allow`, `block`, `bypass` | `allow` |
+| `filter_http_header_*` | Custom headers (e.g., `filter_http_header_X-API-Key`) | - |
+
+### Error Handling
+
+- `allow`: If Guard is unavailable, allow the request (fail-open)
+- `block`: If Guard is unavailable, block the request (fail-closed)
+- `bypass`: Skip this filter if Guard is unavailable
+
+## Testing Your Integration
+
+### 1. Start the Gateway
+
+```bash
+make gds
+# or
+./bin/gatewayd
+```
+
+### 2. Check Firewall Status
+
+Look for this line in the startup logs:
+```
+firewall configured: mode=redact filters=3 (input=2 output=1)
+```
+
+### 3. Send a Test Request
+
+```bash
+curl -X POST http://localhost:8081/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {"role": "user", "content": "My email is test@example.com and SSN is 123-45-6789"}
+    ]
+  }'
+```
+
+### 4. Verify Detection
+
+Check the Gateway logs for firewall activity:
+```
+firewall.input: mode=redact endpoint=/v1/chat/completions
+firewall.input.redacted original_size=119 redacted_size=118
+```
+
+## Billing & Usage
+
+- API calls to Tokligence Guard are metered based on your subscription plan
+- Usage is tracked per API key
+- View usage statistics in the Guard dashboard
+
+## Troubleshooting
+
+### Filter not working
+
+1. Verify `filter_http_enabled = true`
+2. Check the endpoint URL is correct
+3. Verify your API key is valid
+
+### Timeout errors
+
+Increase the timeout:
+```ini
+filter_http_timeout_ms = 10000
+```
+
+### Connection refused
+
+1. Check your network allows outbound HTTPS to Guard endpoints
+2. Verify the endpoint URL includes the correct port (`:7316`)
+
+### API key errors
+
+1. Ensure the API key is active in the Guard dashboard
+2. Check for typos in the configuration
+3. Verify the header name is exactly `X-API-Key`
+
+## Security Best Practices
+
+1. **Never commit API keys** to version control
+2. **Use environment variables** for sensitive configuration
+3. **Enable `redact` mode** in production for balanced security
+4. **Monitor usage** in the Guard dashboard for anomalies
+5. **Rotate API keys** periodically
+
+## Support
+
+- Documentation: [docs.tokligence.ai](https://docs.tokligence.ai)
+- Issues: [github.com/tokligence/tokligence-gateway/issues](https://github.com/tokligence/tokligence-gateway/issues)
+- Email: support@tokligence.ai

--- a/examples/firewall/configs/firewall-enforce.ini
+++ b/examples/firewall/configs/firewall-enforce.ini
@@ -1,46 +1,47 @@
 # Strict Enforcement Configuration
-# This configuration actively blocks requests with critical PII
+# This configuration actively blocks requests with critical sensitive data
 
 [prompt_firewall]
 enabled = true
 mode = enforce
 
-# PII patterns configuration file
+# SD patterns configuration file
 pii_patterns_file = config/pii_patterns.ini
 
 # Enable comprehensive regions for strict enforcement
 pii_regions = global,us,eu
 
-# Very strict limit - block if more than 2 PII entities detected
+# Very strict limit - block if more than 2 SD entities detected
 max_pii_entities = 2
 
 # Log all enforcement decisions
 log_decisions = true
 
-# Don't log actual PII values in production
+# Don't log actual sensitive values in production
 log_pii_values = false
 
 [firewall_input_filters]
 # High-priority regex filter (priority 5)
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 5
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 5
 
-# Presidio for advanced detection (optional, requires Presidio service)
-# Uncomment to enable after starting Presidio sidecar
-# filter_presidio_enabled = true
-# filter_presidio_priority = 10
-# filter_presidio_endpoint = http://localhost:7317/v1/filter/input
-# filter_presidio_timeout_ms = 1000
-# filter_presidio_on_error = block
+# External HTTP filter for advanced detection (optional)
+# Uncomment to enable after configuring external service
+# filter_http_enabled = true
+# filter_http_priority = 10
+# filter_http_endpoint = http://localhost:7317/v1/filter/input
+# filter_http_timeout_ms = 1000
+# filter_http_on_error = block
+# filter_http_header_X-API-Key = tok_your_api_key_here
 
 [firewall_output_filters]
-# Always redact PII in outputs
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 5
+# Always redact sensitive data in outputs
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 5
 
-# Presidio output filter (optional)
-# filter_presidio_enabled = true
-# filter_presidio_priority = 10
-# filter_presidio_endpoint = http://localhost:7317/v1/filter/output
-# filter_presidio_timeout_ms = 1000
-# filter_presidio_on_error = block
+# External HTTP filter (optional)
+# filter_http_enabled = true
+# filter_http_priority = 10
+# filter_http_endpoint = http://localhost:7317/v1/filter/output
+# filter_http_timeout_ms = 1000
+# filter_http_on_error = block

--- a/examples/firewall/configs/firewall-monitor-only.ini
+++ b/examples/firewall/configs/firewall-monitor-only.ini
@@ -5,7 +5,7 @@
 enabled = true
 mode = monitor
 
-# PII patterns configuration file
+# SD patterns configuration file
 pii_patterns_file = config/pii_patterns.ini
 
 # Enable global and US patterns for monitoring
@@ -14,18 +14,18 @@ pii_regions = global,us
 # Log all decisions
 log_decisions = true
 
-# Don't log actual PII values (even in monitor mode)
+# Don't log actual sensitive values (even in monitor mode)
 log_pii_values = false
 
-# Don't limit PII count in monitor mode
+# Don't limit SD count in monitor mode
 max_pii_entities = 999
 
 [firewall_input_filters]
 # Monitor inputs with built-in regex
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
 
 [firewall_output_filters]
 # Monitor outputs for data leakage
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10

--- a/examples/firewall/configs/firewall.ini
+++ b/examples/firewall/configs/firewall.ini
@@ -2,6 +2,9 @@
 #
 # This file configures the Prompt Firewall functionality for protecting
 # sensitive data and preventing security issues in LLM requests/responses.
+#
+# Sensitive Data (SD) includes: email, phone, SSN, credit card, API keys,
+# passwords, private keys, crypto addresses, national IDs, etc.
 
 [prompt_firewall]
 # Enable or disable the firewall completely
@@ -9,25 +12,25 @@ enabled = true
 
 # Firewall mode:
 #   - disabled: Disable firewall entirely (default in code)
-#   - redact: Detect PII, replace with tokens, restore in responses (RECOMMENDED for production)
+#   - redact: Detect SD, replace with tokens, restore in responses (RECOMMENDED)
 #   - monitor: Log violations but allow requests to proceed (for testing)
 #   - enforce: Block requests that violate firewall rules (strict mode)
 mode = redact
 
-# PII patterns configuration file
+# SD patterns configuration file
 pii_patterns_file = config/pii_patterns.ini
 
 # Enabled regions (comma-separated)
 # Available: global, us, cn, eu, uk, ca, au, in, jp, de, fr, sg
 pii_regions = global,us
 
-# Block requests with more than this many PII entities
+# Block requests with more than this many SD entities
 max_pii_entities = 5
 
 # Log all firewall decisions
 log_decisions = true
 
-# Don't log actual PII values in production
+# Don't log actual sensitive values in production
 log_pii_values = false
 
 # Minimum confidence threshold
@@ -35,27 +38,28 @@ pii_min_confidence = 0.75
 
 # Input filters (applied to requests before sending to LLM)
 [firewall_input_filters]
-# Built-in PII regex filter
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
+# Built-in Sensitive Data regex filter
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
 
-# External HTTP filter (Presidio sidecar) - disabled by default
-# Uncomment to enable after starting Presidio sidecar
-# filter_presidio_enabled = false
-# filter_presidio_priority = 20
-# filter_presidio_endpoint = http://localhost:7317/v1/filter/input
-# filter_presidio_timeout_ms = 500
-# filter_presidio_on_error = allow
+# External HTTP filter - disabled by default
+# Can be used with Tokligence Guard, Presidio, or other scanning APIs
+# filter_http_enabled = false
+# filter_http_priority = 20
+# filter_http_endpoint = http://localhost:7317/v1/filter/input
+# filter_http_timeout_ms = 5000
+# filter_http_on_error = allow
+# filter_http_header_X-API-Key = tok_your_api_key_here
 
 # Output filters (applied to LLM responses before returning to client)
 [firewall_output_filters]
-# Built-in PII regex filter for outputs
-filter_pii_regex_enabled = true
-filter_pii_regex_priority = 10
+# Built-in Sensitive Data regex filter for outputs
+filter_sd_regex_enabled = true
+filter_sd_regex_priority = 10
 
-# External HTTP filter (Presidio sidecar) - disabled by default
-# filter_presidio_enabled = false
-# filter_presidio_priority = 20
-# filter_presidio_endpoint = http://localhost:7317/v1/filter/output
-# filter_presidio_timeout_ms = 500
-# filter_presidio_on_error = bypass
+# External HTTP filter - disabled by default
+# filter_http_enabled = false
+# filter_http_priority = 20
+# filter_http_endpoint = http://localhost:7317/v1/filter/output
+# filter_http_timeout_ms = 5000
+# filter_http_on_error = bypass


### PR DESCRIPTION
## Summary
- Rename `filter_pii_regex_*` to `filter_sd_regex_*` (Sensitive Data)
- Rename `filter_presidio_*` to `filter_http_*` (generic HTTP filter)
- Add `filter_http_header_*` support for custom headers (e.g., API keys)
- Maintain backward compatibility with legacy config names

## Configuration Example

```ini
[firewall_input_filters]
# Built-in Sensitive Data regex filter
filter_sd_regex_enabled = true
filter_sd_regex_priority = 10

# External HTTP filter (Tokligence Guard, or other services)
filter_http_enabled = true
filter_http_endpoint = https://us.guard.tokligence.ai:7316/v1/filter/input
filter_http_timeout_ms = 5000
filter_http_on_error = allow
filter_http_header_X-API-Key = tok_your_api_key_here
```

## Test Plan
- [x] All existing tests pass
- [ ] Rebuild and test on live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)